### PR TITLE
var: handle function and undefined for getString()

### DIFF
--- a/jsvm/Var.h
+++ b/jsvm/Var.h
@@ -244,6 +244,10 @@ public:
 			ss << stringV;
 		else if(isObject() || type == ARRAY) 
 			ss << getJSON();
+		else if(isFunction())
+			ss << "function ()";
+		else if(isUndefined())
+			ss << "undefined";
 			
 		return ss.str(); 
 	}


### PR DESCRIPTION
Fix the output of `println(undefined)` and `println(function () {})` :)